### PR TITLE
rfc: odi and poa in vp

### DIFF
--- a/poa-odi-verification/rfc01_poa-odi-verification_embedded-odi-vc.md
+++ b/poa-odi-verification/rfc01_poa-odi-verification_embedded-odi-vc.md
@@ -166,6 +166,7 @@ When requesting the POA the requester should also optionally request the ODI. Us
   "@context": [
       "https://www.w3.org/ns/credentials/v2"
   ],
+  "type": ["VerifiablePresentation"],
   "verifiableCredential": [{
     "@context": [
       "https://www.w3.org/ns/credentials/v2"


### PR DESCRIPTION
I tried to think a little more widely about how to solve the problem of including an ODI with a POA. This is one a those approaches along with #20.

This PR proposes to include both the ODI and POA when presenting credentials. This matches well with the pattern of authorising and action based on multiple credentials. 

If we choose to go down this root, we can evaluate if we give different names to the linked/included ODI which would make clearer where to look for the proof and allow relying parties to choose what method(s) they would accept for ODI.